### PR TITLE
Don't install gems and docs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Attributes
 * `node['ruby_enterprise']['install_path']` - Location to install REE. Default /opt/ruby-enterprise
 * `node['ruby_enterprise']['version']` - Version to install. Looks like `1.8.7-2012.02`
 * `node['ruby_enterprise']['url']` - URL to download. Default is from GoogleCode, with the version specified
+* `node['ruby_enterprise']['dont_install_useful_gems']` - Configure REE with `--dont-install-useful-gems`. true by default
+* `node['ruby_enterprise']['no_dev_docs']` - Configure REE with `--no-dev-docs`. true by default
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,3 +30,5 @@ default['ruby_enterprise']['ruby_bin'] = "/opt/ruby-enterprise/bin/ruby"
 default['ruby_enterprise']['gems_dir'] = "#{ruby_enterprise['install_path']}/lib/ruby/gems/1.8"
 default['ruby_enterprise']['version'] = '1.8.7-2012.02'
 default['ruby_enterprise']['url'] = "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-#{ruby_enterprise['version']}"
+default['ruby_enterprise']['dont_install_useful_gems'] = true
+default['ruby_enterprise']['no_dev_docs'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,10 +48,14 @@ end
 
 bash "Install Ruby Enterprise Edition" do
   cwd Chef::Config[:file_cache_path]
+  flags = ""
+  flags << "--no-dev-docs " if node['ruby_enterprise']['no_dev_docs']
+  flags << "--dont-install-useful-gems " if node['ruby_enterprise']['dont_install_useful_gems']
+
   code <<-EOH
   tar zxf ruby-enterprise-#{ree_ver}.tar.gz
   ruby-enterprise-#{ree_ver}/installer \
-    --auto=#{ree_path}
+    --auto=#{ree_path} #{flags}
   EOH
   not_if do
     ::File.exists?("#{ree_path}/bin/ree-version") &&


### PR DESCRIPTION
Installing gems and docs wastes time on servers.
This configures ree to not install them by default.
It can be changed through attributes, added them to README file
